### PR TITLE
Add suturo_msgs to deps

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,0 +1,3 @@
+- git:
+    local-name: suturo_msgs
+    uri: https://github.com/suturo16/suturo_msgs.git


### PR DESCRIPTION
Ich habe nur suturo_msgs zu den Dependencies in der .rosinstall hinzugefügt, da wir die irgendwann auf jeden Fall brauchen werden.