### PR TITLE
Feature/timestamp of object info

### DIFF
--- a/pr2_command_pool/lisp/commands.lisp
+++ b/pr2_command_pool/lisp/commands.lisp
@@ -14,11 +14,12 @@
 
 (defun get-object-info (object-name)
   (cut:with-vars-bound
-      (?frame ?width ?height ?depth)
+      (?frame ?timestamp ?width ?height ?depth)
       (prolog-get-object-infos object-name)
     (make-object-info
        :name object-name
        :frame (string-downcase ?frame)
+       :timestamp ?timestamp
        :height ?height
        :width ?width
        :depth ?depth)))

--- a/pr2_command_pool/lisp/objects.lisp
+++ b/pr2_command_pool/lisp/objects.lisp
@@ -1,3 +1,3 @@
 (in-package :pr2-command-pool-package)
 
-(defstruct object-info name frame height width depth)
+(defstruct object-info name frame timestamp height width depth)

--- a/pr2_command_pool/lisp/prolog.lisp
+++ b/pr2_command_pool/lisp/prolog.lisp
@@ -13,13 +13,14 @@ frame, height, width and depth as value binding."
 
 ; 'simple' because it uses the simple call
 (defun prolog-get-object-infos-simple (name)
-  (cut:with-vars-bound (|?Frame| |?Width| |?Height| |?Depth|)
+  (cut:with-vars-bound (|?Frame| |?Timestamp| |?Width| |?Height| |?Depth|)
       (cut:lazy-car
        (json-prolog:prolog-simple 
-        (format nil "get_object_infos(knowrob:~a, Frame, Width, Height, Depth)" name) :lispify T))
+        (format nil "get_object_infos(knowrob:~a, Frame, Timestamp, Width, Height, Depth)" name) :lispify T))
     (make-object-info
      :name name
      :frame (string-downcase |?Frame|)
+     :timestamp |?Timestamp|
      :width |?Width|
      :height |?Height|
      :depth |?Depth|)))
@@ -28,7 +29,7 @@ frame, height, width and depth as value binding."
   (cut:lazy-car (json-prolog:prolog
                  `("get_object_infos"
                    ,(format nil "~a~a" +knowrob-iri-prefix+ name)
-                   ?frame ?width ?height ?depth) :lispify T)))
+                   ?frame ?timestamp ?width ?height ?depth) :lispify T)))
 
 ;;                                         ; Some other templates. Try their worth.
 ;; (defun prolog-get-object-frame-eagerly (prolog-function-name type)


### PR DESCRIPTION
Extend get-object-info and object-info struct by timestamp 


Corresponding Trello ticket:
https://trello.com/c/jYa45tEv/37-get-object-info-um-timestamp-erweitern