### PR TITLE
[NICHT DIREKT MERGEN] Failure Handling mit Retries

### DIFF
--- a/plan_execution/lisp/plans.lisp
+++ b/plan_execution/lisp/plans.lisp
@@ -6,68 +6,62 @@
           (progn ,@body)
        (beliefstate:stop-node log-node :success ,T))))
 
-(cram-language:def-cram-function grasp (obj-info arm)
+
+(defun check-object-location (obj-info)
+  "Return t if the object of OBJ-INFO is still at the same location."
+  (when obj-info
+    ;(get-in-base-pose)
+    ;turn head
+    ;(service-run-pipeline)
+    (when (seen-since obj-info)
+      T)))
+
+
+(cpl:def-cram-function grasp (obj-info arm)
   "Grasp the object described by OBJECT-INFO with ARM.\
 
 OBJ-INFO (obj-info): Description of the target object.
 ARM (string): Which arm to use. Use one of the constants defined in planning-common."
-  (ros-info "grasp" "Starting to grasp object ~a with arm ~a."
-            (pr2-do::object-info-name obj-info)
+  (ros-info (grasp) "Starting to grasp object ~a with arm ~a."
+            (common:object-info-name obj-info)
             arm)
-  ;;(if (pr2-do::check-object-location obj-info)
-      ;; grasp it
+  (if (check-object-location obj-info)
+      ;; if object found, grasp it
       (with-logging-node "GRASP-OBJECT"
-        (beliefstate::annotate-resource "objectInfo" (pr2-do::object-info-name obj-info) "knowrob")
+        (beliefstate::annotate-resource "objectInfo" (common:object-info-name obj-info) "knowrob")
         (beliefstate::annotate-resource "arm" arm "knowrob")
         ;; grasp it
         (seq
-          (alexandria:switch ((pr2-do::object-info-name obj-info) :test #'equal)
+          (alexandria:switch ((common:object-info-name obj-info) :test #'equal)
             ("Knife" (grasp-knife obj-info arm))
             ("Cylinder" (grasp-object obj-info arm)))
-          (pr2-do::connect-obj-with-gripper obj-info arm)
-          (ros-info "grasp" "Connected object ~a with arm ~a."
-                    (pr2-do::object-info-name obj-info)
+          (pr2-do:connect-obj-with-gripper obj-info arm)
+          (ros-info (grasp) "Connected object ~a with arm ~a."
+                    (common:object-info-name obj-info)
                     arm)))
       ;; else complain
-      ;;(ros-error "grasp" "Object ~a not found" (pr2-do::object-info-name obj-info)))
-  )
+      (ros-error "grasp" "Object ~a not found" (common:object-info-name obj-info))))
   
-
 
 (defun grasp-knife (knife-info arm)
   "Grasp the knife described by KNIFE-INFO with ARM."
-;; (pr2-do::grasp-knife knife-info arm)
-;; (pr2-do::close-gripper arm 100)
-  (ms2-grasp-knife knife-info arm))
+  (pr2-do:grasp-knife knife-info arm)
+  (ros-info (grasp knife) "Close gripper.")
+  (pr2-do:close-gripper arm 100))
 
-(defun ms2-grasp-knife (knife-info arm)
-  (ros-info "ms2-grasp-knife" "connect Knife frame to ododm.")
-  (pr2-do::service-connect-frames "/odom_combined"  "/Knife")
-  (ros-info "ms2-grasp-knife" "grasp the knife.")
-  (pr2-do::grasp-knife knife-info arm)
-  (ros-info "ms2-grasp-knife" "close-gripper")
-  (pr2-do::close-gripper arm 100)
-  (ros-info "ms2-grasp-knife" "reconnect frames from odom to arm")
- 
- ;; (pr2-do::detach-knife-from-rack (pr2-do::get-object-info "Knife") pr2-do::+right-arm+)
-  (pr2-do::prolog-disconnect-frames "/odom_combined" "/Knife")
-  (pr2-do::service-connect-frames "/r_wrist_roll_link" "/Knife")
-  (pr2-do::get-in-base-pose)
-  ;;TODO: test detach, add it in here. 
-  )
 
 (defun grasp-object (obj-info arm)
   "Grasp the object described by OBJECT-INFO with ARM."
-  (ros-info "grasp-object" "Open gripper")
-  (pr2-do::open-gripper arm)
-  (ros-info "grasp-object" "Move arm to object ~a." (pr2-do::object-info-name obj-info))
-  (pr2-do::move-arm-to-object obj-info arm)
-  (ros-info "grasp-object" "Close gripper.")
-  (pr2-do::close-gripper arm 50)
-  (ros-info "grasp-object" "Done."))
+  (ros-info (grasp object) "Open gripper")
+  (pr2-do:open-gripper arm)
+  (ros-info (grasp object) "Move arm to object ~a." (common:object-info-name obj-info))
+  (pr2-do:move-arm-to-object obj-info arm)
+  (ros-info (grasp object) "Close gripper.")
+  (pr2-do:close-gripper arm 50)
+  (ros-info (grasp object) "Done."))
 
 
-(cram-language:def-cram-function place-object (obj-info loc-info arm)
+(cpl:def-cram-function place-object (obj-info loc-info arm)
   "Place object described by OBJECT-INFO at location described by LOCATION-INFO with ARM.
 Assuming the object is placed on ARM's gripper.
 
@@ -75,63 +69,80 @@ OBJ-INFO (common:obj-info): Description of the target object.
 LOC-INFO (common:obj-info): Description of target location.
 ARM (string): Which arm to use. Use one of the constants defined in planning-common."
   (with-logging-node "PLACE-OBJECT"
-    (beliefstate::annotate-resource "objectInfo" (pr2-do::object-info-name obj-info) "knowrob")
+    (beliefstate::annotate-resource "objectInfo" (common:object-info-name obj-info) "knowrob")
     (beliefstate::annotate-resource "locationInfo" loc-info "knowrob")
     (beliefstate::annotate-resource "arm" arm "knowrob")
-    (ros-info "place-object" "Move object with arm.")
-    (pr2-do::move-object-with-arm loc-info obj-info arm)
-    (ros-info "place-object" "Open gripper.")
-    (pr2-do::open-gripper arm)
-    (ros-info "place-object" "Done.")))
+    (ros-info (place-object) "Move object with arm.")
+    (pr2-do:move-object-with-arm loc-info obj-info arm)
+    (ros-info (place-object) "Open gripper.")
+    (pr2-do:open-gripper arm)
+    (ros-info (place-object) "Done.")))
 
 
-(cram-language:def-cram-function detach-object-from-rack (obj-info arm)
+(cpl:def-cram-function detach-object-from-rack (obj-info arm)
   "Detach object described by OBJECT-INFO from the rack with ARM.
 Assume object is attached to the rack.
 
 OBJ-INFO (obj-info): Description of the target object.
 ARM (string): Which arm to use. Use one of the constants defined in planning-common."
   ;; this doesn't work, I think the axes are wrong since bot moves his torso down
-  (pr2-do::detach-knife-from-rack obj-info arm)
-  ;;(pr2-do::get-in-base-pose)
-  )
+  (ros-info (detach-object-from-rack) "Detaching.")
+  (pr2-do:detach-knife-from-rack obj-info arm)
+  (ros-info (detach-object-from-rack) "Done."))
   
 
-(cram-language:def-cram-function cut-object (arm knife-info cake-info)
+(cpl:def-cram-function cut-object (arm knife-info cake-info)
   "Cut object described by CAKE-INFO with knife described by KNIFE-INFO using ARM.
 Assume the knife is in the gripper of ARM.
 
 CAKE-INFO (obj-info): Description of the target object.
 KNIFE-INFO (obj-info): Description of the cutting tool.
 ARM (string): Which arm to use. Use one of the constants defined in planning-common."
- ;;(if (pr2-do::check-object-location cake-info)
+ (if (check-object-location cake-info)
       ;; if object is found, cut it
       (with-logging-node "CUT-OBJECT"
-        (beliefstate::annotate-resource "knifeInfo" (pr2-do::object-info-name knife-info) "knowrob")
-        (beliefstate::annotate-resource "cakeInfo" (pr2-do::object-info-name cake-info) "knowrob")
+        (beliefstate::annotate-resource "knifeInfo" (common:object-info-name knife-info) "knowrob")
+        (beliefstate::annotate-resource "cakeInfo" (common:object-info-name cake-info) "knowrob")
         (beliefstate::annotate-resource "arm" arm "knowrob")
-        (pr2-do::service-connect-frames "/odom_combined" "/Box")
-        (ros-info "-cut-object" "Getting into cutting position.")
-        (pr2-do::take-cutting-position cake-info knife-info arm 0.01)
-        (ros-info "cut-object" "Cutting.")
-        (pr2-do::cut-cake cake-info knife-info arm 0.01)
+        (common:service-connect-frames "/odom_combined" "/Box")
+        (ros-info (cut-object) "Getting into cutting position.")
+        (pr2-do:take-cutting-position cake-info knife-info arm 0.01)
+        (ros-info (cut-object) "Cutting.")
+        (pr2-do:cut-cake cake-info knife-info arm 0.01)
         ; TODO(cpo): get cake-piece-info
         ; (pr2-do::push-aside cake-info cake-piece-info)
-        (ros-info "cut-object" "Done."))
+        (ros-info (cut-object) "Done."))
       ;; else complain
-      ;;(ros-error "cut-object" "Cannot find object '~a', which I am supposed to cut."
-                 ;;(pr2-do::object-info-name cake-info)))
+      (ros-error (cut-object) "Cannot find object '~a', which I am supposed to cut."
+                 (common:object-info-name cake-info))))
+
+
+(defun ms2-grasp-knife (knife-info arm)
+  (ros-info (ms2-grasp-knife) "connect Knife frame to ododm.")
+  (common:service-connect-frames "/odom_combined"  "/Knife")
+  (ros-info (ms2-grasp-knife) "grasp the knife.")
+  (pr2-do:grasp-knife knife-info arm)
+  (ros-info (ms2-grasp-knife) "close-gripper")
+  (pr2-do:close-gripper arm 100)
+  ;; (pr2-do::detach-knife-from-rack (pr2-do::get-object-info "Knife") pr2-do::+right-arm+)
+  (ros-info (ms2-grasp-knife) "reconnect frames from odom to arm")
+  (common:prolog-disconnect-frames "/odom_combined" "/Knife")
+  (common:service-connect-frames "/r_wrist_roll_link" "/Knife")
+  (pr2-do:get-in-base-pose)
+  ;;TODO: test detach, add it in here.
   )
 
+
 (defun ms2-cut-cake (cake-info knife-info arm)
-  (pr2-do::service-connect-frames "/odom_combined" "/Box")
+  (common:service-connect-frames "/odom_combined" "/Box")
   (ros-info "ms2-cut-object" "Getting into cutting position.")
-  (pr2-do::take-cutting-position cake-info knife-info arm 0.01)
+  (pr2-do:take-cutting-position cake-info knife-info arm 0.01)
   (ros-info "ms2-cut-object" "Cutting.")
-  (pr2-do::cut-cake cake-info knife-info arm 0.01)
+  (pr2-do:cut-cake cake-info knife-info arm 0.01)
   (ros-info "ms2-cut-cake" "Done."))
 
+
 (defun ms2-full-demo ()
-  (plan-execution-package::ms2-grasp-knife (common:get-object-info "Knife") pr2-do::+right-arm+ )
-  (pr2-do::get-in-base-pose)
-  (plan-execution-package::ms2-cut-cake (pr2-do::get-object-info "Box") (pr2-do::get-object-info "Knife") pr2-do::+right-arm+))
+  (ms2-grasp-knife (common:get-object-info "Knife") common:+right-arm+ )
+  (pr2-do:get-in-base-pose)
+  (ms2-cut-cake (common:get-object-info "Box") (common:get-object-info "Knife") common:+right-arm+))

--- a/planning_common/lisp/conditions.lisp
+++ b/planning_common/lisp/conditions.lisp
@@ -24,3 +24,10 @@
   ((description :initform "Action goal was lost."))
   (:documentation "Action goal was lost."))
 
+(define-condition perception-pipeline-failure (low-level-failure)
+  ((description :initform "Pipeline could not be started."))
+  (:documentation "Pipeline could not be started."))
+
+(define-condition seen-since-failure (low-level-failure)
+  ((description :initform "Seen since acting up."))
+  (:documentation "Seen since acting up."))

--- a/planning_common/lisp/conditions.lisp
+++ b/planning_common/lisp/conditions.lisp
@@ -1,0 +1,26 @@
+(in-package :common)
+
+(define-condition low-level-failure (cpl:simple-plan-failure)
+  ((description :initarg :description
+                :initform "Low-level function did not succeed."
+                :reader error-description))
+  (:documentation "Low-level function did not succeed.")
+  (:report (lambda (condition stream)
+             (format stream (error-description condition)))))
+
+(define-condition high-level-failure (cpl:simple-plan-failure)
+  ((description :initarg :description
+                :initform "High-level plan did not succeed."
+                :reader error-description))
+  (:documentation "High-level plan did not succeed.")
+  (:report (lambda (condition stream)
+             (format stream (error-description condition)))))
+
+(define-condition action-timeout (low-level-failure)
+  ((description :initform "Action call timed out."))
+  (:documentation "Action call timed out."))
+
+(define-condition action-lost (low-level-failure)
+  ((description :initform "Action goal was lost."))
+  (:documentation "Action goal was lost."))
+

--- a/planning_common/lisp/package.lisp
+++ b/planning_common/lisp/package.lisp
@@ -15,6 +15,8 @@
    :high-level-failure
    :action-timeout
    :action-lost
+   :perception-pipeline-failure
+   :seen-since-failure
    
    :object-info
    :make-object-info
@@ -44,7 +46,11 @@
    :strings->KeyValues
    :get-joint-config
    :get-controller-specs
-   :seen-since
+
+   :run-full-pipeline
+   :run-pipeline
+   :connect-objects
+   :disconnect-objects
    :get-object-info))
 
 (in-package :planning-common-package)

--- a/planning_common/lisp/package.lisp
+++ b/planning_common/lisp/package.lisp
@@ -11,6 +11,11 @@
    :+double+
    :+transform+
 
+   :low-level-failure
+   :high-level-failure
+   :action-timeout
+   :action-lost
+   
    :object-info
    :make-object-info
    :object-info-name
@@ -24,7 +29,8 @@
    :service-connect-frames
 
    :action-move-robot
-   
+
+   :prolog-seen-since
    :prolog-disconnect-frames
    
    :ensure-node-is-running

--- a/planning_common/lisp/utils.lisp
+++ b/planning_common/lisp/utils.lisp
@@ -62,15 +62,6 @@ STRINGS (list of strings): Alternating keys and values. Has to have an even leng
   (sleep 5)
   (print "done recognizing things. You can start planning now!"))
 
-(defun seen-since (obj-info)
-  "Check if object described by OBJ-INFO is still at the last known location."
-  (let ((name (object-info-name obj-info))
-        (frame-id (object-info-frame obj-info))
-        (timestamp (object-info-timestamp obj-info)))
-    (if (prolog-seen-since name frame-id timestamp)
-        T
-        NIL)))
-
 (defun connect-objects (parent-info child-info)
   "Connect objects described by PARENT-INFO and CHILD-INFO
 using prolog interface."

--- a/planning_common/lisp/utils.lisp
+++ b/planning_common/lisp/utils.lisp
@@ -62,6 +62,13 @@ STRINGS (list of strings): Alternating keys and values. Has to have an even leng
   (sleep 5)
   (print "done recognizing things. You can start planning now!"))
 
+(defun run-pipeline (obj-type)
+  "Run perception pipeline for OBJ-TYPE."
+  (let ((unrecognized-objs (service-run-pipeline obj-type)))
+    (when unrecognized-objs
+      (error 'perception-pipeline-failure))
+    unrecognized-objs))
+
 (defun connect-objects (parent-info child-info)
   "Connect objects described by PARENT-INFO and CHILD-INFO
 using prolog interface."

--- a/planning_common/planning-common-system.asd
+++ b/planning_common/planning-common-system.asd
@@ -13,6 +13,7 @@
   ((:module "lisp"
     :components
     ((:file "package")
+     (:file "conditions" :depends-on ("package"))
      (:file "objects" :depends-on ("package"))
      (:file "topics" :depends-on ("package"))
      (:file "services" :depends-on ("package"))

--- a/pr2_command_pool/lisp/commands.lisp
+++ b/pr2_command_pool/lisp/commands.lisp
@@ -8,15 +8,6 @@
   "Call action to open the gripper of ARM."
   (action-move-gripper 0.09 arm 70))
 
-(defun check-object-location (obj-info)
-  "Return t if the object of OBJ-INFO is still at the same location."
-  (when obj-info
-    ;(get-in-base-pose)
-    ;turn head
-    ;(service-run-pipeline)
-    (when (seen-since obj-info)
-      T)))
-
 (defun disconnect-obj-from-arm (obj-info arm)
   "Call Prolog to disconnect the object of OBJ-INFO from ARM."
   (prolog-disconnect-frames

--- a/pr2_command_pool/lisp/package.lisp
+++ b/pr2_command_pool/lisp/package.lisp
@@ -1,3 +1,18 @@
 (defpackage :pr2-command-pool-package
   (:nicknames :pr2-do)
-  (:use :cl :roslisp :common))
+  (:use :cl :roslisp :common)
+
+  (:export
+
+   ;; commands
+   :close-gripper
+   :open-gripper
+   :disconnect-obj-from-arm
+   :connect-obj-with-gripper
+   :move-arm-to-object
+   :move-object-with-arm
+   :get-in-base-pose
+   :grasp-knife
+   :detach-knife-from-rack
+   :take-cutting-position
+   :cut-cake))

--- a/sut_mockups/scripts/graspkard.py
+++ b/sut_mockups/scripts/graspkard.py
@@ -21,7 +21,7 @@ class MovementServer(TemplateActionServer):
                 self.server.set_preempted()
                 break
             if feedback.current_value > 0:
-                feedback.alteration_rate = round(random.uniform(0.3, 0.7), 1)
+                feedback.alteration_rate = round(random.uniform(0.4, 0.8), 1)
                 feedback.current_value -= feedback.alteration_rate
             self.server.publish_feedback(feedback)
             r.sleep()


### PR DESCRIPTION
Ich habe ein paar Conditions definiert, die vom Action-Call signalisiert werden, wenn ein Timeout passiert oder ein Goal verloren wird.

Beim Timeout wird das Signal aufgefangen und ein Retry ausgeführt. Kommt dann noch eins kommt der Fehler an die Oberfläche. Beim Goal verlieren wandert der Fehler zurzeit direkt an die Oberfläche.

Ob man beim Timeout direkt abbrechen will müsste man sich nochmal überlegen.